### PR TITLE
fix: update leapkit url

### DIFF
--- a/docs/built_with_doco.md
+++ b/docs/built_with_doco.md
@@ -13,7 +13,7 @@ The following is a list of the documentation sites that have been built with Doc
 [Retabler](https://docs.retabler.com) is a platform that facilitates data importing processes within companies. It provides an embeddable data importing widget that can be used with your application's data models.
 
 ## LeapKit
-[LeapKit](https://leapkit.sh) is a Web framework to quickly get started building web applications in Go. It provides a set of tools and libraries to help you build web applications quickly.
+[LeapKit](https://leapkit.dev) is a Web framework to quickly get started building web applications in Go. It provides a set of tools and libraries to help you build web applications quickly.
 
 ## Doco
 This website was also built with Doco. I guess you know that 😅.


### PR DESCRIPTION
Going through the Build With Doco section and found out the LeapKit link is broken. This change updates leapkit.sh to leapkit.dev to use the correct url.